### PR TITLE
More tests relating to external phase encoding tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM mrtrix3-builder AS mrtrix3-eval-builder
 # Further software updates applied to MRtrix3 to fix handling of orientation-dependent metadata,
 #   in particular external phase encoding tables,
 #   from: https://github.com/MRtrix3/mrtrix3/pull/3128
-ARG MRTRIX3_GIT_COMMITISH="fac8009ee91df38e145936365b903a8c7dc61c09"
+ARG MRTRIX3_GIT_COMMITISH="3.0.8"
 # Command-line arguments for `./configure`
 ARG MRTRIX3_CONFIGURE_FLAGS="-nogui"
 # Command-line arguments for `./build`
@@ -156,4 +156,3 @@ ENV FSLDIR="/opt/fsl" \
     PATH="/opt/mrtrix3/bin:/opt/peakscmds/build/bin:/opt/dcm2niix/build/bin:/opt/fsl/share/fsl/bin:$PATH"
 
 ENTRYPOINT ["/main.py"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN apt-get -qq update \
 
 FROM mrtrix3-builder AS mrtrix3-eval-builder
 # Version of MRtrix3 to be evaluated
-# Software updates applied to MRtrix3 to fix handling of orientation-dependent metadata
-#   was integrated into the 3.0.5 update
-ARG MRTRIX3_GIT_COMMITISH="3.0.5"
+# Further software updates applied to MRtrix3 to fix handling of orientation-dependent metadata,
+#   in particular external phase encoding tables,
+#   from: https://github.com/MRtrix3/mrtrix3/pull/3128
+ARG MRTRIX3_GIT_COMMITISH="fac8009ee91df38e145936365b903a8c7dc61c09"
 # Command-line arguments for `./configure`
 ARG MRTRIX3_CONFIGURE_FLAGS="-nogui"
 # Command-line arguments for `./build`

--- a/dwi_metadata/dcm2niix/dcm2niix.py
+++ b/dwi_metadata/dcm2niix/dcm2niix.py
@@ -7,7 +7,8 @@ import shutil
 import subprocess
 from tqdm import tqdm
 
-from dwi_metadata import VARIANTS
+from dwi_metadata import ACQUISITIONS
+from dwi_metadata import FILE_FORMATS
 from dwi_metadata import tests
 
 logger = logging.getLogger(__name__)
@@ -16,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 def test_dcm2niix(dicomdir, dcm2niixdir):
     run(dicomdir, op.abspath(dcm2niixdir))
-    tests.metadata('dcm2niix', dcm2niixdir, ('nii', 'json', 'bvec', 'bval'))
-    
+    tests.metadata('dcm2niix', dcm2niixdir, FILE_FORMATS[0], tests.MetadataTests(True, True, True))
+
 
 
 def run(indir, outdir):
@@ -30,11 +31,11 @@ def run(indir, outdir):
     os.makedirs(outdir)
     os.chdir(indir)
     logger.info(f'Running dcm2niix')
-    for v in tqdm(VARIANTS, desc='Running dcm2niix'):
+    for acq in tqdm(ACQUISITIONS, desc='Running dcm2niix'):
         subprocess.run(['dcm2niix',
                         '-o', outdir,
                         '-f', '%f',
-                        f'{v}'],
+                        f'{acq}'],
                        capture_output=True,
                        check=True)
     os.chdir(cwd)

--- a/dwi_metadata/fsl/applytopup.py
+++ b/dwi_metadata/fsl/applytopup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+
+from os import path as op
+import subprocess
+from tqdm import tqdm
+import numpy
+
+from dwi_metadata import ACQUISITIONS
+
+
+def run(dicomdir, topupdir, applytopupdir, strides):
+
+    mrconvert_cmd = ['mrconvert',
+                      '-quiet',
+                      '-coord', '3', '0',
+                      '-axes', '0,1,2',
+                      #'-config', 'RealignTransform', 'true', # Shouldn't matter
+                      '-strides', ','.join(map(str, strides[0:3]))]
+
+    applytopup_image_list = []
+    for acq in tqdm(ACQUISITIONS,
+                    desc='Running applytopup on individual volumes',
+                    leave=False):
+        temp_image_path = op.join(applytopupdir, f'{acq}.nii')
+        temp_eddycfg_path = op.join(applytopupdir, f'{acq}.cfg')
+        temp_eddyidx_path = op.join(applytopupdir, f'{acq}.idx')
+        subprocess.run(mrconvert_cmd
+                       + [op.join(dicomdir, f'{acq}'),
+                          temp_image_path,
+                          '-export_pe_eddy', temp_eddycfg_path, temp_eddyidx_path],
+                       check=True)
+        # While applytopup will run on images that claim to have phase encoding along the third axis,
+        #   it will have no effect on the image data
+        eddycfg_data = numpy.loadtxt(temp_eddycfg_path)
+        if eddycfg_data[2] != 0:
+            continue
+        applytopup_image_path = op.join(applytopupdir, f'{acq}_applytopup.nii.gz')
+        subprocess.run(['applytopup',
+                        f'--imain={temp_image_path}',
+                        f'--datain={temp_eddycfg_path}',
+                        '--inindex=1',
+                        f'--topup={op.join(topupdir, "out")}',
+                        f'--out={applytopup_image_path}',
+                        '--method=jac'],
+                       check=True)
+        applytopup_image_list.append(applytopup_image_path)
+
+    subprocess.run(['mrcat',
+                    '-quiet',
+                    '-axis', '3',
+                    '-config', 'RealignTransform', 'false']
+                    + applytopup_image_list
+                    + [op.join(applytopupdir, 'applytopup.mif')],
+                   check=True)

--- a/dwi_metadata/fsl/bedpostx.py
+++ b/dwi_metadata/fsl/bedpostx.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from tqdm import tqdm
 
-from .. import VARIANTS
+from .. import ACQUISITIONS
 
 logger = logging.getLogger(__name__)
 
@@ -30,13 +30,13 @@ def run(indir, maskdir, bedpostxdir):
     cwd = os.getcwd()
     logger.info(f'Running FSL bedpostx from input {indir}')
     os.chdir(bedpostxdir)
-    for v in tqdm(VARIANTS, desc=f'Running FSL bedpostx on input {indir}'):
-        bedpostx_tmpdir = f'{v}/'
+    for acq in tqdm(ACQUISITIONS, desc=f'Running FSL bedpostx on input {indir}'):
+        bedpostx_tmpdir = f'{acq}/'
         os.makedirs(bedpostx_tmpdir)
-        os.symlink(op.join(indir, f'{v}.nii'), op.join(bedpostx_tmpdir, 'data.nii'))
-        os.symlink(op.join(indir, f'{v}.bvec'), op.join(bedpostx_tmpdir, 'bvecs'))
-        os.symlink(op.join(indir, f'{v}.bval'), op.join(bedpostx_tmpdir, 'bvals'))
-        os.symlink(op.join(maskdir, f'{v}.nii'), op.join(bedpostx_tmpdir, 'nodif_brain_mask.nii'))
+        os.symlink(op.join(indir, f'{acq}.nii'), op.join(bedpostx_tmpdir, 'data.nii'))
+        os.symlink(op.join(indir, f'{acq}.bvec'), op.join(bedpostx_tmpdir, 'bvecs'))
+        os.symlink(op.join(indir, f'{acq}.bval'), op.join(bedpostx_tmpdir, 'bvals'))
+        os.symlink(op.join(maskdir, f'{acq}.nii'), op.join(bedpostx_tmpdir, 'nodif_brain_mask.nii'))
         subprocess.run(['bedpostx', bedpostx_tmpdir] + OPTIONS,
                        capture_output=True,
                        check=True)
@@ -53,8 +53,8 @@ def convert(bedpostxdir, conversiondir, use_dyads):
         pass
     os.makedirs(conversiondir)
     logger.info(f'Converting {bedpostxdir} to MRtrix3 format')
-    for v in tqdm(VARIANTS, desc=f'Converting FSL {bedpostxdir} to MRtrix3 format'):
-        bedpostx_subdir = os.path.join(bedpostxdir, f'{v}.bedpostX')
+    for acq in tqdm(ACQUISITIONS, desc=f'Converting FSL {bedpostxdir} to MRtrix3 format'):
+        bedpostx_subdir = os.path.join(bedpostxdir, f'{acq}.bedpostX')
         tmppath = op.join(conversiondir, 'tmp.mif')
         if use_dyads:
             for index in range(1, 4):
@@ -79,7 +79,7 @@ def convert(bedpostxdir, conversiondir, use_dyads):
                 os.remove(op.join(conversiondir, f'tmp{index}.mif'))
             subprocess.run(['peaksconvert',
                             tmppath,
-                            op.join(conversiondir, f'{v}.mif'),
+                            op.join(conversiondir, f'{acq}.mif'),
                             '-in_format', '3vector',
                             '-in_reference', 'bvec',
                             '-out_format', '3vector',
@@ -106,7 +106,7 @@ def convert(bedpostxdir, conversiondir, use_dyads):
                            check=True)
             subprocess.run(['peaksconvert',
                             tmppath,
-                            op.join(conversiondir, f'{v}.mif'),
+                            op.join(conversiondir, f'{acq}.mif'),
                             '-in_format', 'spherical',
                             '-in_reference', 'bvec',
                             '-out_format', '3vector',

--- a/dwi_metadata/fsl/dtifit.py
+++ b/dwi_metadata/fsl/dtifit.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 from tqdm import tqdm
 
-from .. import VARIANTS
+from .. import ACQUISITIONS
 
 logger = logging.getLogger(__name__)
 
@@ -18,13 +18,13 @@ def run(indir, maskdir, dtifitdir):
         pass
     os.makedirs(dtifitdir)
     logger.info(f'Running FSL dtifit from input {indir}')
-    for v in tqdm(VARIANTS, desc=f'Running FSL dtifit on {indir}'):
+    for acq in tqdm(ACQUISITIONS, desc=f'Running FSL dtifit on {indir}'):
         subprocess.run(['dtifit',
-                        '-k', op.join(indir, f'{v}.nii'),
-                        '-o', op.join(dtifitdir, f'{v}'),
-                        '-m', op.join(maskdir, f'{v}.nii'),
-                        '-r', op.join(indir, f'{v}.bvec'),
-                        '-b', op.join(indir, f'{v}.bval'),
+                        '-k', op.join(indir, f'{acq}.nii'),
+                        '-o', op.join(dtifitdir, f'{acq}'),
+                        '-m', op.join(maskdir, f'{acq}.nii'),
+                        '-r', op.join(indir, f'{acq}.bvec'),
+                        '-b', op.join(indir, f'{acq}.bval'),
                         '--wls',
                         '--save_tensor'],
                        capture_output=True,
@@ -32,13 +32,13 @@ def run(indir, maskdir, dtifitdir):
         subprocess.run(['mrcalc',
                         '-config', 'RealignTransform', 'false',
                         '-quiet',
-                        op.join(dtifitdir, f'{v}_V1.nii.gz'),
-                        op.join(dtifitdir, f'{v}_FA.nii.gz'),
+                        op.join(dtifitdir, f'{acq}_V1.nii.gz'),
+                        op.join(dtifitdir, f'{acq}_FA.nii.gz'),
                         '-mult',
-                        op.join(dtifitdir, f'{v}.nii')],
+                        op.join(dtifitdir, f'{acq}.nii')],
                        check=True)
         for suffix in ('V1', 'V2', 'V3', 'FA', 'L1', 'L2', 'L3', 'MD', 'MO', 'S0'):
-            os.remove(op.join(dtifitdir, f'{v}_{suffix}.nii.gz'))
+            os.remove(op.join(dtifitdir, f'{acq}_{suffix}.nii.gz'))
 
 
 
@@ -49,10 +49,10 @@ def convert(dtifitdir, conversiondir):
         pass
     os.makedirs(conversiondir)
     logger.info(f'Converting {dtifitdir} to MRtrix3 format')
-    for v in tqdm(VARIANTS, desc=f'Converting FSL {dtifitdir} to MRtrix3 format'):
+    for acq in tqdm(ACQUISITIONS, desc=f'Converting FSL {dtifitdir} to MRtrix3 format'):
         subprocess.run(['peaksconvert',
-                        op.join(dtifitdir, f'{v}.nii'),
-                        op.join(conversiondir, f'{v}.mif'),
+                        op.join(dtifitdir, f'{acq}.nii'),
+                        op.join(conversiondir, f'{acq}.mif'),
                         '-in_format', '3vector',
                         '-in_reference', 'bvec',
                         '-out_format', '3vector',

--- a/dwi_metadata/fsl/eddy.py
+++ b/dwi_metadata/fsl/eddy.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+
+import os
+from os import path as op
+import subprocess
+from tqdm import tqdm
+
+from dwi_metadata import ACQUISITIONS
+
+
+def run(dicomdir, topupdir, eddydir, mask_path, strides):
+
+    mrconvert_cmd = ['mrconvert',
+                     '-quiet',
+                     '-config', 'RealignTransform', 'true',
+                     '-strides', ','.join(map(str, strides))]
+
+    mrcat_image_list = []
+
+    # TODO Concatenating all volumes for all acquisitions takes way too long for eddy to process
+    # Want to derive a set of mrconvert calls that will extract just the first b=0
+    #   and a small number of DWIs from each acquisition such that the net DWI coverage
+    #   is reasonable but the total number of volumes processed is smaller
+    # DWI table of acquisition is:
+    #   - 1 x b=0
+    #   - 12 x b=1500
+    #   - 1 x b=0
+    #   - 13 x b=1500
+    #   - 1 x b=0
+    # Across the set of acquisitions to use
+    #   (16 or 24 depending on whether phase encoding along the third axis is permitted),
+    #   pull the lead b=0 and then one or more suitable DWIs
+    #   such that each diffusion sensitisation direction appears only once
+
+    # TODO Can eddy deal with volumes with phase encoding along the third axis?
+    #for acq in tqdm([item for item in ACQUISITIONS if item.pedir not in ('HF', 'FH')],
+    for acq in tqdm(ACQUISITIONS,
+                    desc='Conforming DICOM series for concatenation for eddy',
+                    leave=False):
+        temp_image_path = op.join(eddydir, f'{acq}.mif')
+        subprocess.run(mrconvert_cmd
+                       + [op.join(dicomdir, f'{acq}'),
+                          temp_image_path],
+                       check=True)
+        mrcat_image_list.append(temp_image_path)
+
+    concat_image_path = op.join(eddydir, 'in.mif')
+    subprocess.run(['mrcat',
+                    '-quiet',
+                    '-config', 'RealignTransform', 'false',
+                    '-axis', '3']
+                   + mrcat_image_list
+                   + [concat_image_path],
+                   check=True)
+
+    eddy_in_image_path = op.join(eddydir, 'in.nii')
+    eddy_config_path = op.join(eddydir, 'in.cfg')
+    eddy_index_path = op.join(eddydir, 'in.idx')
+    eddy_bvec_path = op.join(eddydir, 'in.bvec')
+    eddy_bval_path = op.join(eddydir, 'in.bval')
+    subprocess.run(['mrconvert',
+                    '-quiet',
+                    '-config', 'RealignTransform', 'false',
+                    concat_image_path,
+                    eddy_in_image_path,
+                    '-export_pe_eddy', eddy_config_path, eddy_index_path,
+                    '-export_grad_fsl', eddy_bvec_path, eddy_bval_path],
+                   check=True)
+    os.remove(concat_image_path)
+
+    eddy_mask_path = op.join(eddydir, 'mask.nii')
+    subprocess.run(['mrconvert',
+                    '-quiet',
+                    mask_path,
+                    eddy_mask_path,
+                    '-strides', ','.join(map(str, strides[0:3])),
+                    '-datatype', 'uint8'],
+                   check=True)
+
+    subprocess.run(['eddy',
+                    f'--imain={eddy_in_image_path}',
+                    f'--mask={eddy_mask_path}',
+                    f'--index={eddy_index_path}',
+                    f'--acqp={eddy_config_path}',
+                    f'--bvecs={eddy_bvec_path}',
+                    f'--bvals={eddy_bval_path}',
+                    '--mb=2',
+                    f'--topup={op.join(topupdir, "out")}',
+                    '--flm=linear',
+                    #'--interp=linear', # Would be faster, but seems to crash
+                    f'--out={op.join(eddydir, "out")}'],
+                   check=True)

--- a/dwi_metadata/fsl/fsl.py
+++ b/dwi_metadata/fsl/fsl.py
@@ -110,11 +110,11 @@ def test_preproc(dicomdir, scratchdir):
     logger.info(f'Check applytopup images: mrview {scratchdir}/applytopup/*/applytopup.mif')
 
     # TODO Require further work before eddy tests can run in reasonable time
-    #os.makedirs(op.join(scratchdir, 'eddy'))
-    #for stride_name, stride_list in tqdm(FSLPREPROC_STRIDES.items(), desc='Testing FSL eddy'):
-    #    topupdir = op.join(scratchdir, 'topup', stride_name)
-    #    eddydir = op.join(scratchdir, 'eddy', stride_name)
-    #    os.makedirs(eddydir)
-    #    eddy.run(dicomdir, topupdir, eddydir, op.join(scratchdir, 'mask.nii'), stride_list)
-    #logger.info(f'Check eddy images: {scratchdir}/eddy/*')
+    os.makedirs(op.join(scratchdir, 'eddy'))
+    for stride_name, stride_list in tqdm(FSLPREPROC_STRIDES.items(), desc='Testing FSL eddy'):
+        topupdir = op.join(scratchdir, 'topup', stride_name)
+        eddydir = op.join(scratchdir, 'eddy', stride_name)
+        os.makedirs(eddydir)
+        eddy.run(dicomdir, topupdir, eddydir, op.join(scratchdir, 'mask.nii'), stride_list)
+    logger.info(f'Check eddy images: {scratchdir}/eddy/*')
 

--- a/dwi_metadata/fsl/fsl.py
+++ b/dwi_metadata/fsl/fsl.py
@@ -1,11 +1,33 @@
 #!/usr/bin/python3
 
+import logging
+import os
 from os import path as op
+import subprocess
+from tqdm import tqdm
 
+from dwi_metadata import ACQUISITIONS
 from dwi_metadata import tests
+from . import applytopup
 from . import bedpostx
 from . import dtifit
+from . import eddy
+from . import topup
 
+logger = logging.getLogger(__name__)
+
+
+# FSL topup will not run if an image claims to have phase encoding along the third axis;
+#   therefore can't do every possible permutation
+# TODO Can play with permutation of the first two axes
+FSLPREPROC_STRIDES = {'RAS': [1, 2, 3, 4],
+                      'LAS': [-1, 2, 3, 4],
+                      'LPS': [-1, -2, 3, 4],
+                      'RPS': [1, -2, 3, 4],
+                      'RAI': [1, 2, -3, 4],
+                      'LAI': [-1, 2, -3, 4],
+                      'LPI': [-1, -2, -3, 4],
+                      'RPI': [1, -2, -3, 4]}
 
 
 def test_dtifit(scratchdir):
@@ -24,13 +46,13 @@ def test_dtifit(scratchdir):
             op.join(scratchdir, 'mask_dcm2niix'),
             scratchdir)
     execute('MRtrix3 mrconvert without reorientation',
-            op.join(scratchdir, 'mrconvert_dcm2niijsonbvecbvalFalse'),
-            op.join(scratchdir, 'mask_mrconvert_dcm2niijsonbvecbvalFalse'),
-            scratchdir)                        
+            op.join(scratchdir, 'mrconvert_dcm2niibvecbvaljsonFalse'),
+            op.join(scratchdir, 'mask_mrconvert_dcm2niibvecbvaljsonFalse'),
+            scratchdir)
     execute('MRtrix3 mrconvert with reorientation',
-            op.join(scratchdir, 'mrconvert_dcm2niijsonbvecbvalTrue'),
-            op.join(scratchdir, 'mask_mrconvert_dcm2niijsonbvecbvalTrue'),
-            scratchdir)        
+            op.join(scratchdir, 'mrconvert_dcm2niibvecbvaljsonTrue'),
+            op.join(scratchdir, 'mask_mrconvert_dcm2niibvecbvaljsonTrue'),
+            scratchdir)
 
 
 
@@ -60,11 +82,39 @@ def test_bedpostx(scratchdir):
             op.join(scratchdir, 'mask_dcm2niix'),
             scratchdir)
     execute('MRtrix3 mrconvert without reorientation',
-            op.join(scratchdir, 'mrconvert_dcm2niijsonbvecbvalFalse'),
-            op.join(scratchdir, 'mask_mrconvert_dcm2niijsonbvecbvalFalse'),
+            op.join(scratchdir, 'mrconvert_dcm2niibvecbvaljsonFalse'),
+            op.join(scratchdir, 'mask_mrconvert_dcm2niibvecbvaljsonFalse'),
             scratchdir)
     execute('MRtrix3 mrconvert with reorientation',
-            op.join(scratchdir, 'mrconvert_dcm2niijsonbvecbvalTrue'),
-            op.join(scratchdir, 'mask_mrconvert_dcm2niijsonbvecbvalTrue'),
+            op.join(scratchdir, 'mrconvert_dcm2niibvecbvaljsonTrue'),
+            op.join(scratchdir, 'mask_mrconvert_dcm2niibvecbvaljsonTrue'),
             scratchdir)
+
+
+
+def test_preproc(dicomdir, scratchdir):
+
+    os.makedirs(op.join(scratchdir, 'topup'))
+    for stride_name, stride_list in tqdm(FSLPREPROC_STRIDES.items(), desc='Testing FSL topup'):
+        topupdir = op.join(scratchdir, 'topup', stride_name)
+        os.makedirs(topupdir)
+        topup.run(dicomdir, topupdir, stride_list)
+    logger.info(f'Check topup images: mrview {scratchdir}/topup/*/corr.nii.gz')
+
+    os.makedirs(op.join(scratchdir, 'applytopup'))
+    for stride_name, stride_list in tqdm(FSLPREPROC_STRIDES.items(), desc='Testing FSL applytopup'):
+        topupdir = op.join(scratchdir, 'topup', stride_name)
+        applytopupdir = op.join(scratchdir, 'applytopup', stride_name)
+        os.makedirs(applytopupdir)
+        applytopup.run(dicomdir, topupdir, applytopupdir, stride_list)
+    logger.info(f'Check applytopup images: mrview {scratchdir}/applytopup/*/applytopup.mif')
+
+    # TODO Require further work before eddy tests can run in reasonable time
+    #os.makedirs(op.join(scratchdir, 'eddy'))
+    #for stride_name, stride_list in tqdm(FSLPREPROC_STRIDES.items(), desc='Testing FSL eddy'):
+    #    topupdir = op.join(scratchdir, 'topup', stride_name)
+    #    eddydir = op.join(scratchdir, 'eddy', stride_name)
+    #    os.makedirs(eddydir)
+    #    eddy.run(dicomdir, topupdir, eddydir, op.join(scratchdir, 'mask.nii'), stride_list)
+    #logger.info(f'Check eddy images: {scratchdir}/eddy/*')
 

--- a/dwi_metadata/fsl/topup.py
+++ b/dwi_metadata/fsl/topup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/python3
 
+import os
 from os import path as op
 import subprocess
 from tqdm import tqdm
 
 from dwi_metadata import ACQUISITIONS
+
+TOPUP_CONFIG_PATH = op.join(os.environ['FSLDIR'], 'etc', 'flirtsch', 'b02b0_2.cnf')
 
 
 def run(indir, localdir, strides):
@@ -62,5 +65,6 @@ def run(indir, localdir, strides):
                     f'--datain={concat_petable_path}',
                     f'--out={topup_out_prefix}',
                     f'--fout={topup_field_out}',
-                    f'--iout={topup_image_out}'],
+                    f'--iout={topup_image_out}',
+                    f'--config={TOPUP_CONFIG_PATH}'],
                    check=True)

--- a/dwi_metadata/fsl/topup.py
+++ b/dwi_metadata/fsl/topup.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+from os import path as op
+import subprocess
+from tqdm import tqdm
+
+from dwi_metadata import ACQUISITIONS
+
+
+def run(indir, localdir, strides):
+
+    # Sensible concatenation of these images can't occur
+    #   unless the transforms are realigned first
+    mrconvert_cmd = ['mrconvert',
+                      '-quiet',
+                      '-coord', '3', '0',
+                      '-axes', '0,1,2',
+                      '-config', 'RealignTransform', 'true',
+                      '-strides', ','.join(map(str, strides[0:3]))]
+
+    image_paths = []
+    for acq in tqdm(ACQUISITIONS,
+                    desc='Extracting and converting first volume of each series',
+                    leave=False):
+        temp_image_path = op.join(localdir, f'{acq}.mif')
+        subprocess.run(mrconvert_cmd +
+                        [op.join(indir, f'{acq}'),
+                        temp_image_path],
+                       check=True)
+        pe_dir = subprocess.run(['mrinfo',
+                                 '-config', 'RealignTransform', 'false',
+                                 temp_image_path,
+                                 '-property', 'PhaseEncodingDirection'],
+                                 capture_output=True).stdout
+        if 'k' not in pe_dir.decode():
+            image_paths.append(temp_image_path)
+
+    concat_image_path_mif = op.join(localdir, 'all.mif')
+    subprocess.run(['mrcat',
+                    '-quiet',
+                    '-axis', '3',
+                    '-config', 'RealignTransform', 'false']
+                   + image_paths
+                   + [concat_image_path_mif],
+                   check=True)
+
+    concat_image_path_nii = op.join(localdir, 'in.nii')
+    concat_petable_path = op.join(localdir, 'in.txt')
+    subprocess.run(['mrconvert',
+                    '-quiet',
+                    '-config', 'RealignTransform', 'false',
+                    concat_image_path_mif,
+                    concat_image_path_nii,
+                    '-export_pe_topup', concat_petable_path],
+                   check=True)
+
+    topup_out_prefix = op.join(localdir, 'out')
+    topup_field_out = op.join(localdir, 'field.nii')
+    topup_image_out = op.join(localdir, 'corr.nii')
+    subprocess.run(['topup',
+                    f'--imain={concat_image_path_nii}',
+                    f'--datain={concat_petable_path}',
+                    f'--out={topup_out_prefix}',
+                    f'--fout={topup_field_out}',
+                    f'--iout={topup_image_out}'],
+                   check=True)

--- a/dwi_metadata/mrtrix3/dwi2mask.py
+++ b/dwi_metadata/mrtrix3/dwi2mask.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 from tqdm import tqdm
 
-from .. import VARIANTS
+from .. import ACQUISITIONS
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +23,9 @@ def run(indir, outdir, outpath):
     os.makedirs(outdir)
     logger.info(f'Running MRtrix3 dwi2mask')
     mrmath_cmd = ['mrmath']
-    for v in tqdm(VARIANTS, desc='Generating homologated brain mask'):
-        out_path = op.join(outdir, f'{v}.mif')
-        subprocess.run(['dwi2mask', op.join(indir, f'{v}/'), out_path,
+    for acq in tqdm(ACQUISITIONS, desc='Generating homologated brain mask'):
+        out_path = op.join(outdir, f'{acq}.mif')
+        subprocess.run(['dwi2mask', op.join(indir, f'{acq}/'), out_path,
                         '-config', 'RealignTransform', 'true',
                         '-quiet'],
                        check=True)
@@ -33,8 +33,8 @@ def run(indir, outdir, outpath):
     mrmath_cmd.extend(['max', outpath, '-datatype', 'bit', '-quiet'])
     subprocess.run(mrmath_cmd, check=True)
     logger.info(f'dwi2mask results aggregated as {outpath}')
-    for v in VARIANTS:
-        os.remove(op.join(outdir, f'{v}.mif'))
+    for acq in ACQUISITIONS:
+        os.remove(op.join(outdir, f'{acq}.mif'))
 
 
 
@@ -48,9 +48,9 @@ def convert(indir, in_extension, maskpath, outdir, out_extension):
     # This is not fixed per variant; it depends on the image to which the mask is to be matched,
     #   and this could depend on the conversion software / whether or not MRtrix3 performed transform realignment
     logger.info(f'Converting aggregate mask to match {indir}')
-    for v in tqdm(VARIANTS, desc=f'Back-propagating homologated brain mask to match {indir}', leave=False):
-        inpath = op.join(indir, f'{v}.{in_extension}')
-        outpath = op.join(outdir, f'{v}.{out_extension}')
+    for acq in tqdm(ACQUISITIONS, desc=f'Back-propagating homologated brain mask to match {indir}', leave=False):
+        inpath = op.join(indir, f'{acq}.{in_extension}')
+        outpath = op.join(outdir, f'{acq}.{out_extension}')
         if not op.exists(inpath):
             raise FileNotFoundError(f'Cannot convert mask for "{inpath}"')
         in_strides = subprocess.run(['mrinfo', inpath,

--- a/dwi_metadata/mrtrix3/dwi2tensor.py
+++ b/dwi_metadata/mrtrix3/dwi2tensor.py
@@ -7,32 +7,33 @@ import shutil
 import subprocess
 from tqdm import tqdm
 
-from .. import VARIANTS
+from .. import ACQUISITIONS
+from .. import GradType
 
 logger = logging.getLogger(__name__)
 
-def run(indir, extensions, maskdir, dwi2tensordir):
+def run(indir, formats, maskdir, dwi2tensordir):
     try:
         shutil.rmtree(dwi2tensordir)
     except OSError:
         pass
     os.makedirs(dwi2tensordir)
     logger.info(f'Running MRtrix3 dwi2tensor from input {indir}')
-    for v in tqdm(VARIANTS, desc=f'Running MRtrix3 dwi2tensor on {indir}', leave=False):
-        tensor_image_path = op.join(dwi2tensordir, f'{v}_tensor.{extensions[0]}')
-        mask_path = op.join(maskdir, f'{v}.{extensions[0]}')
+    for acq in tqdm(ACQUISITIONS, desc=f'Running MRtrix3 dwi2tensor on {indir}', leave=False):
+        tensor_image_path = op.join(dwi2tensordir, f'{acq}_tensor.{formats.image_extension}')
+        mask_path = op.join(maskdir, f'{acq}.{formats.image_extension}')
         grad_option = []
-        if all(ext in extensions for ext in ('bvec', 'bval')):
-            grad_option = ['-fslgrad', op.join(indir, f'{v}.bvec'), op.join(indir, f'{v}.bval')]
-        elif 'grad' in extensions:
-            grad_option = ['-grad', op.join(indir, f'{v}.grad')]
-        subprocess.run(['dwi2tensor', op.join(indir, f'{v}.{extensions[0]}'), tensor_image_path,
+        if formats.grad_type == GradType.fsl:
+            grad_option = ['-fslgrad', op.join(indir, f'{acq}.bvec'), op.join(indir, f'{acq}.bval')]
+        elif formats.grad_type == GradType.b:
+            grad_option = ['-grad', op.join(indir, f'{acq}.grad')]
+        subprocess.run(['dwi2tensor', op.join(indir, f'{acq}.{formats.image_extension}'), tensor_image_path,
                         '-mask', mask_path,
                         '-quiet']
                        + grad_option,
                        check=True)
         subprocess.run(['tensor2metric', tensor_image_path,
-                        '-vector', op.join(dwi2tensordir, f'{v}.{extensions[0]}'),
+                        '-vector', op.join(dwi2tensordir, f'{acq}.{formats.image_extension}'),
                         '-mask', mask_path,
                         '-modulate', 'fa',
                         '-quiet'],

--- a/dwi_metadata/mrtrix3/mrconvert.py
+++ b/dwi_metadata/mrtrix3/mrconvert.py
@@ -7,35 +7,44 @@ import shutil
 import subprocess
 from tqdm import tqdm
 
-from .. import VARIANTS
+from .. import ACQUISITIONS
+from .. import GradType
+from .. import KeyvalueType
+from .. import PEType
 
 logger = logging.getLogger(__name__)
 
 
 
-def run_dicom(indir, outdir, extensions, reorient):
+def run_dicom(indir, outdir, formats, reorient):
     try:
         shutil.rmtree(outdir)
     except OSError:
         pass
     os.makedirs(outdir)
     logger.info(f'Running MRtrix3 mrconvert from DICOM: '
-                f'File extensions {",".join(extensions)}, reorient {reorient}')
-    for v in tqdm(VARIANTS,
+                f'{formats.description}, reorient {reorient}')
+    for acq in tqdm(ACQUISITIONS,
                   desc=f'Running MRtrix3 mrconvert: '
-                       f'DICOM -> {",".join(extensions)}, {"with" if reorient else "without"} reorientation',
+                       f'DICOM -> {formats.description}, {"with" if reorient else "without"} reorientation',
                   leave=False):
         cmd = ['mrconvert',
-               op.join(indir, f'{v}/'),
-               op.join(outdir, f'{v}.{extensions[0]}'),
+               op.join(indir, f'{acq}/'),
+               op.join(outdir, f'{acq}.{formats.image_extension}'),
                '-config', 'RealignTransform', str(reorient),
                '-quiet']
-        if 'json' in extensions:
-            cmd.extend(['-json_export', op.join(outdir, f'{v}.json')])
-        if 'bvec' in extensions and 'bval' in extensions:
-            cmd.extend(['-export_grad_fsl', op.join(outdir, f'{v}.bvec'), op.join(outdir, f'{v}.bval')])
-        if 'grad' in extensions:
-            cmd.extend(['-export_grad_mrtrix', op.join(outdir, f'{v}.grad')])
+        if formats.keyvalue_type == KeyvalueType.json:
+            cmd.extend(['-json_export', op.join(outdir, f'{acq}.json')])
+        if formats.grad_type == GradType.fsl:
+            cmd.extend(['-export_grad_fsl', op.join(outdir, f'{acq}.bvec'), op.join(outdir, f'{acq}.bval')])
+        elif formats.grad_type == GradType.b:
+            cmd.extend(['-export_grad_mrtrix', op.join(outdir, f'{acq}.grad')])
+        if formats.pe_type == PEType.table:
+            cmd.extend(['-export_pe_table', op.join(outdir, f'{acq}.petable')])
+        if formats.pe_type == PEType.topup:
+            cmd.extend(['-export_pe_topup', op.join(outdir, f'{acq}.topup')])
+        elif formats.pe_type == PEType.eddy:
+            cmd.extend(['-export_pe_eddy', op.join(outdir, f'{acq}.eddycfg'), op.join(outdir, f'{acq}.eddyidx')])
         subprocess.run(cmd, check=True)
 
 
@@ -43,8 +52,8 @@ def run_dicom(indir, outdir, extensions, reorient):
 
 def run_intermediate(indir,
                      outdir,
-                     extensions_in,
-                     extensions_out,
+                     formats_in,
+                     formats_out,
                      reorient,
                      strides_option):
     try:
@@ -52,32 +61,47 @@ def run_intermediate(indir,
     except OSError:
         pass
     os.makedirs(outdir)
-    logger.info(f'Running {len(VARIANTS)} instances of mrconvert from intermediate input:')
-    logger.info(f'  Input {indir}, input file extensions {",".join(extensions_in)};')
-    logger.info(f'  Output file extensions {",".join(extensions_out)}, reorient {reorient}, strides {strides_option}')
-    for v in tqdm(VARIANTS,
+    logger.info(f'Running {len(ACQUISITIONS)} instances of mrconvert from intermediate input:')
+    logger.info(f'  Input {indir}, input formats {formats_in.description};')
+    logger.info(f'  Output formats {formats_out.description}, reorient {reorient}, strides {strides_option}')
+    for acq in tqdm(ACQUISITIONS,
                   desc='Running MRtrix3 mrconvert: '
-                       f'{indir} {",".join(extensions_in)} -> {",".join(extensions_out)}, '
+                       f'{formats_in.description} -> {formats_out.description}, '
                        f'{"with" if reorient else "without"} reorientation, '
                        f'strides {strides_option}',
                   leave=False):
         cmd = ['mrconvert',
-               op.join(indir, f'{v}.{extensions_in[0]}'),
-               op.join(outdir, f'{v}.{extensions_out[0]}'),
+               op.join(indir, f'{acq}.{formats_in.image_extension}'),
+               op.join(outdir, f'{acq}.{formats_out.image_extension}'),
                '-config', 'RealignTransform', str(reorient),
                '-quiet']
-        if 'json' in extensions_in:
-            cmd.extend(['-json_import', op.join(indir, f'{v}.json')])
-        if 'bvec' in extensions_in and 'bval' in extensions_in:
-            cmd.extend(['-fslgrad', op.join(indir, f'{v}.bvec'), op.join(indir, f'{v}.bval')])
-        if 'grad' in extensions_in:
-            cmd.extend(['-grad', op.join(indir, f'{v}.grad')])
-        if 'json' in extensions_out:
-            cmd.extend(['-json_export', op.join(outdir, f'{v}.json')])
-        if 'bvec' in extensions_out and 'bval' in extensions_out:
-            cmd.extend(['-export_grad_fsl', op.join(outdir, f'{v}.bvec'), op.join(outdir, f'{v}.bval')])
-        if 'grad' in extensions_out:
-            cmd.extend(['-export_grad_mrtrix', op.join(outdir, f'{v}.grad')])
+        if formats_in.keyvalue_type == KeyvalueType.json:
+            cmd.extend(['-json_import', op.join(indir, f'{acq}.json')])
+        if formats_in.grad_type == GradType.fsl:
+            cmd.extend(['-fslgrad', op.join(indir, f'{acq}.bvec'), op.join(indir, f'{acq}.bval')])
+        elif formats_in.grad_type == GradType.b:
+            cmd.extend(['-grad', op.join(indir, f'{acq}.grad')])
+        if formats_in.pe_type == PEType.table:
+            cmd.extend(['-import_pe_table', op.join(indir, f'{acq}.petable')])
+        elif formats_in.pe_type == PEType.topup:
+            cmd.extend(['-import_pe_topup', op.join(indir, f'{acq}.topup')])
+        elif formats_in.pe_type == PEType.eddy:
+            cmd.extend(['-import_pe_eddy', op.join(indir, f'{acq}.eddycfg'), op.join(indir, f'{acq}.eddyidx')])
+        if (formats_in.keyvalue_type != KeyvalueType.none and formats_out.keyvalue_type == KeyvalueType.json) \
+                or (formats_in.pe_type != PEType.none and formats_out.pe_type == PEType.json):
+            cmd.extend(['-json_export', op.join(outdir, f'{acq}.json')])
+        if formats_in.grad_type != GradType.none:
+            if formats_out.grad_type == GradType.fsl:
+                cmd.extend(['-export_grad_fsl', op.join(outdir, f'{acq}.bvec'), op.join(outdir, f'{acq}.bval')])
+            elif formats_out.grad_type == GradType.b:
+                cmd.extend(['-export_grad_mrtrix', op.join(outdir, f'{acq}.grad')])
+        if formats_in.pe_type != PEType.none:
+            if formats_out.pe_type == PEType.table:
+                cmd.extend(['-export_pe_table', op.join(outdir, f'{acq}.petable')])
+            elif formats_out.pe_type == PEType.topup:
+                cmd.extend(['-export_pe_topup', op.join(outdir, f'{acq}.topup')])
+            elif formats_out.pe_type == PEType.fsl:
+                cmd.extend(['-export_pe_eddy', op.join(outdir, f'{acq}.eddycfg'), op.join(outdir, f'{acq}.eddyidx')])
         if strides_option:
             cmd.extend(['-strides', strides_option])
         subprocess.run(cmd, check=True)

--- a/dwi_metadata/mrtrix3/mrconvert.py
+++ b/dwi_metadata/mrtrix3/mrconvert.py
@@ -100,7 +100,7 @@ def run_intermediate(indir,
                 cmd.extend(['-export_pe_table', op.join(outdir, f'{acq}.petable')])
             elif formats_out.pe_type == PEType.topup:
                 cmd.extend(['-export_pe_topup', op.join(outdir, f'{acq}.topup')])
-            elif formats_out.pe_type == PEType.fsl:
+            elif formats_out.pe_type == PEType.eddy:
                 cmd.extend(['-export_pe_eddy', op.join(outdir, f'{acq}.eddycfg'), op.join(outdir, f'{acq}.eddyidx')])
         if strides_option:
             cmd.extend(['-strides', strides_option])

--- a/dwi_metadata/mrtrix3/mrtrix3.py
+++ b/dwi_metadata/mrtrix3/mrtrix3.py
@@ -1,18 +1,26 @@
 #!/usr/bin/python3
 
+import itertools
+import logging
+import os
 from os import path as op
 import shutil
-import itertools
+import subprocess
 from tqdm import tqdm
+import numpy
 
-from dwi_metadata import EXTENSIONS
-from dwi_metadata import VARIANTS
+from dwi_metadata import FILE_FORMATS
+from dwi_metadata import ACQUISITIONS
+from dwi_metadata import GradType
+from dwi_metadata import KeyvalueType
+from dwi_metadata import PEType
 from dwi_metadata import tests
 
 from . import dwi2mask
 from . import dwi2tensor
 from . import mrconvert
 
+logger = logging.getLogger(__name__)
 
 
 # Make sure we get complex non-standard strides that are both LHS and RHS coordinate systems
@@ -25,67 +33,200 @@ STRIDES = {'unmodified': None,
 
 
 def test_mrconvert_from_dicom(dicomdir, scratchdir):
-    for extensions, reorient in tqdm(itertools.product(EXTENSIONS, (False, True)), 
+    for formats, reorient in tqdm(itertools.product(FILE_FORMATS, (False, True)),
                                      desc='Evaluating MRtrix3 mrconvert from DICOM',
-                                     total=len(EXTENSIONS)*2):
-        outdir = op.join(scratchdir, f'mrconvert_dcm2{"".join(extensions)}{reorient}')
+                                     total=len(FILE_FORMATS)*2):
+        outdir = op.join(scratchdir, f'mrconvert_dcm2{"".join(formats.symbolic_name)}{reorient}')
         mrconvert.run_dicom(dicomdir,
                             outdir,
-                            extensions,
+                            formats,
                             reorient)
-        tests.metadata(f'mrconvert: DICOM to {",".join(extensions)} '
+        tests.metadata(f'mrconvert: DICOM to {formats.description} '
                        f'{"with" if reorient else "without"} reorientation',
                        outdir,
-                       extensions)
+                       formats,
+                       tests.MetadataTests(formats.grad_type != GradType.none,
+                                           formats.pe_type != PEType.none,
+                                           formats.keyvalue_type != KeyvalueType.none))
 
 
 
 def test_mrconvert_from_dcm2niix(dcm2niixdir, scratchdir):
-    for extensions, reorient, (strides_name, strides_option) in \
-        tqdm(itertools.product(EXTENSIONS, (False, True), STRIDES.items()),
+    for formats, reorient, (strides_name, strides_option) in \
+        tqdm(itertools.product(FILE_FORMATS, (False, True), STRIDES.items()),
              desc='Evaluating MRtrix3 mrconvert from dcm2niix',
-             total=len(EXTENSIONS)*2*len(STRIDES)):
-             
-        outdir = op.join(scratchdir, f'dcm2niix2{"".join(extensions)}{reorient}{strides_name}')
+             total=len(FILE_FORMATS)*2*len(STRIDES)):
+
+        outdir = op.join(scratchdir, f'dcm2niix2{formats.symbolic_name}{reorient}{strides_name}')
         mrconvert.run_intermediate(dcm2niixdir,
                                    outdir,
-                                   ['nii', 'json', 'bvec', 'bval'],
-                                   extensions,
+                                   FILE_FORMATS[0],
+                                   formats,
                                    reorient,
                                    strides_option)
-        tests.metadata(f'mrconvert: dcm2niix to {",".join(extensions)} '
+        tests.metadata(f'mrconvert: dcm2niix to {formats.description} '
                        f'{"with" if reorient else "without"} reorientation '
                        f'& {strides_name} strides',
                        outdir,
-                       extensions)
+                       formats,
+                       tests.MetadataTests(formats.grad_type != GradType.none,
+                                           formats.pe_type != PEType.none,
+                                           formats.keyvalue_type != KeyvalueType.none))
         shutil.rmtree(outdir)
 
 
 
 
 def test_mrconvert_from_mrconvert(scratchdir):
-    for extensions_intermediate, reorient_intermediate, extensions_out, reorient_out, (strides_name, strides_option) \
-        in tqdm(itertools.product(EXTENSIONS, (False, True), EXTENSIONS, (False, True), STRIDES.items()),
+    for formats_intermediate, reorient_intermediate, formats_out, reorient_out, (strides_name, strides_option) \
+        in tqdm(itertools.product(FILE_FORMATS, (False, True), FILE_FORMATS, (False, True), STRIDES.items()),
                 desc='Evaluating MRtrix3 mrconvert from multiple formats with stride manipulation',
-                total=len(EXTENSIONS)*2*len(EXTENSIONS)*2*len(STRIDES)):
-                
-        intermediatedir = op.join(scratchdir, f'mrconvert_dcm2{"".join(extensions_intermediate)}{reorient_intermediate}')
-        outdir = op.join(scratchdir, f'mrconvert_{"".join(extensions_intermediate)}{reorient_intermediate}'
-                                     f'2{"".join(extensions_out)}{reorient_out}{strides_name}')
+                total=len(FILE_FORMATS)*2*len(FILE_FORMATS)*2*len(STRIDES)):
+
+        # Some combinations of input and output we can skip as there's no tests to do
+        if not (formats_intermediate.grad_type != GradType.none and formats_out.grad_type != GradType.none \
+                or formats_intermediate.pe_type != PEType.none and formats_out.pe_type != PEType.none \
+                or formats_intermediate.keyvalue_type != KeyvalueType.none and formats_out.keyvalue_type != KeyvalueType.none):
+            continue
+
+        intermediatedir = op.join(scratchdir, f'mrconvert_dcm2{formats_intermediate.symbolic_name}{reorient_intermediate}')
+        outdir = op.join(scratchdir, f'mrconvert_{formats_intermediate.symbolic_name}{reorient_intermediate}'
+                                     f'2{"".join(formats_out.symbolic_name)}{reorient_out}{strides_name}')
         mrconvert.run_intermediate(intermediatedir,
                                    outdir,
-                                   extensions_intermediate,
-                                   extensions_out,
+                                   formats_intermediate,
+                                   formats_out,
                                    reorient_out,
                                    strides_option)
-        tests.metadata(f'mrconvert: {",".join(extensions_intermediate)} '
+        tests.metadata(f'mrconvert: {formats_intermediate.description} '
                        f'{"with" if reorient_intermediate else "without"} reorientation '
-                       f'to {",".join(extensions_out)} '
+                       f'to {formats_out.description} '
                        f'{"with" if reorient_out else "without"} reorientation '
                        f'& {strides_name} strides',
                        outdir,
-                       extensions_out)
+                       formats_out,
+                       tests.MetadataTests(formats_intermediate.grad_type != GradType.none and formats_out.grad_type != GradType.none,
+                                           formats_intermediate.pe_type != PEType.none and formats_out.pe_type != PEType.none,
+                                           formats_intermediate.keyvalue_type != KeyvalueType.none and formats_out.keyvalue_type != KeyvalueType.none))
         shutil.rmtree(outdir)
+
+
+
+def test_petables(dicomdir, scratchdir):
+    os.makedirs(op.join(scratchdir, 'petables'))
+    temp_image_path = op.join(scratchdir, 'petables', 'temp.mif')
+    errors = []
+    for acq, reorient in tqdm(itertools.product(ACQUISITIONS, (False, True)),
+                              desc='Testing PE table import/export',
+                              total=len(ACQUISITIONS)*2):
+        reftable_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}.txt')
+        subprocess.run(['mrinfo',
+                        op.join(dicomdir, f'{acq}'),
+                        '-export_pe_table', reftable_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        reftable_data = numpy.loadtxt(reftable_path)
+        # For exporting table to file,
+        #   may be different behaviour depending on whether output image path is NIfTI or other;
+        #   therefore need to test both
+        table_nii_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_nifti.table')
+        table_nii_image_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_table.nii')
+        subprocess.run(['mrconvert',
+                        op.join(dicomdir, f'{acq}'),
+                        table_nii_image_path,
+                        '-export_pe_table', table_nii_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        table_mif_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_mrtrix.table')
+        table_mif_image_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_table.mif')
+        subprocess.run(['mrconvert',
+                        op.join(dicomdir, f'{acq}'),
+                        table_mif_image_path,
+                        '-export_pe_table', table_mif_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        topup_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}.topup')
+        topup_image_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_topup.nii')
+        subprocess.run(['mrconvert',
+                        op.join(dicomdir, f'{acq}'),
+                        topup_image_path,
+                        '-export_pe_topup', topup_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        eddycfg_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}.cfg')
+        eddyidx_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}.idx')
+        eddy_image_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_eddy.nii')
+        subprocess.run(['mrconvert',
+                        op.join(dicomdir, f'{acq}'),
+                        eddy_image_path,
+                        '-export_pe_eddy', eddycfg_path, eddyidx_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        # TODO Produce a version of the image that does not contain phase encoding information
+        #   (Or use one that has been pre-generated elsewhere)
+        from_table_nii_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_fromtable_nii.txt')
+        from_table_mif_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_fromtable_mif.txt')
+        from_topup_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_fromtopup.txt')
+        from_eddy_path = op.join(scratchdir, 'petables', f'{acq}_{reorient}_fromeddy.txt')
+        subprocess.run(['mrconvert',
+                        table_nii_image_path,
+                        temp_image_path,
+                        '-import_pe_table', table_nii_path,
+                        '-export_pe_table', from_table_nii_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        os.remove(temp_image_path)
+        # TODO Necessary to first wipe the phase encoding information from the .mif header?
+        subprocess.run(['mrconvert',
+                        table_mif_image_path,
+                        temp_image_path,
+                        '-import_pe_table', table_mif_path,
+                        '-export_pe_table', from_table_mif_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        os.remove(temp_image_path)
+        subprocess.run(['mrconvert',
+                        topup_image_path,
+                        temp_image_path,
+                        '-import_pe_topup', topup_path,
+                        '-export_pe_table', from_topup_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        os.remove(temp_image_path)
+        subprocess.run(['mrconvert',
+                        eddy_image_path,
+                        temp_image_path,
+                        '-import_pe_eddy', eddycfg_path, eddyidx_path,
+                        '-export_pe_table', from_eddy_path,
+                        '-config', 'RealignTransform', f'{reorient}',
+                        '-quiet'],
+                       check=True)
+        os.remove(temp_image_path)
+        from_table_nii_data = numpy.loadtxt(from_table_nii_path)
+        from_table_mif_data = numpy.loadtxt(from_table_mif_path)
+        from_topup_data = numpy.loadtxt(from_topup_path)
+        from_eddy_data = numpy.loadtxt(from_eddy_path)
+        if not numpy.array_equal(reftable_data, from_table_nii_data):
+            errors.append((f'{acq}', reorient, 'table_nii'))
+        if not numpy.array_equal(reftable_data, from_table_mif_data):
+            errors.append((f'{acq}', reorient, 'table_mif'))
+        if not numpy.array_equal(reftable_data, from_topup_data):
+            errors.append((f'{acq}', reorient, 'topup'))
+        if not numpy.array_equal(reftable_data, from_eddy_data):
+            errors.append((f'{acq}', reorient, 'eddy'))
+
+    if errors:
+        logger.error(f'{len(errors)} errors found in phase encoding table handling:')
+        for error in errors:
+            logger.error(f'  {error[0]}, {"with" if error[1] else "without"} reorientation, converted to {error[2]}')
 
 
 
@@ -95,21 +236,21 @@ def convert_mask(dcm2niixdir, maskpath, scratchdir):
                      maskpath,
                      op.join(scratchdir, 'mask_dcm2niix'),
                      'nii')
-    for extensions, reorient in tqdm(itertools.product(EXTENSIONS, (False, True)),
+    for formats, reorient in tqdm(itertools.product(FILE_FORMATS, (False, True)),
                                      desc='Back-propagating brain mask to MRtrix3 mrconvert outputs'):
-        version_string = f'dcm2{"".join(extensions)}{reorient}'
+        version_string = f'dcm2{formats.symbolic_name}{reorient}'
         mrtrixdir = op.join(scratchdir, f'mrconvert_{version_string}')
         dwi2mask.convert(mrtrixdir,
-                         extensions[0],
+                         formats.image_extension,
                          maskpath,
                          op.join(scratchdir, f'mask_mrconvert_{version_string}'),
-                         extensions[0])
+                         formats.image_extension)
 
 
 
 def test_dwi2tensor(scratchdir):
     dwi2tensor.run(op.join(scratchdir, 'dcm2niix'),
-                   ['nii', 'json', 'bvec', 'bval'],
+                   FILE_FORMATS[0],
                    op.join(scratchdir, 'mask_dcm2niix'),
                    op.join(scratchdir, 'dwi2tensor_from_dcm2niix'))
     tests.peaks(f'MRtrix3 dwi2tensor from dcm2niix',
@@ -117,19 +258,21 @@ def test_dwi2tensor(scratchdir):
                 op.join(scratchdir, 'mask_dcm2niix'),
                 'nii',
                 'nii')
-    for extensions, reorient in tqdm(itertools.product(EXTENSIONS, (False, True)),
+    for formats, reorient in tqdm(itertools.product(FILE_FORMATS, (False, True)),
                                      desc='Running MRtrix3 dwi2tensor on MRtrix3 mrconvert outputs',
-                                     total=len(EXTENSIONS)*2):
-        version_string = f'dcm2{"".join(extensions)}{reorient}'
+                                     total=len(FILE_FORMATS)*2):
+        if formats.grad_type == GradType.none:
+            continue
+        version_string = f'dcm2{formats.symbolic_name}{reorient}'
         outdir = op.join(scratchdir, f'dwi2tensor_from_mrconvert_{version_string}')
         maskdir = op.join(scratchdir, f'mask_mrconvert_{version_string}')
         dwi2tensor.run(op.join(scratchdir, f'mrconvert_{version_string}'),
-                       extensions,
+                       formats,
                        maskdir,
                        outdir)
         tests.peaks(f'MRtrix3 dwi2tensor from mrconvert {version_string}',
                     outdir,
                     maskdir,
-                    extensions[0],
-                    extensions[0])
+                    formats.image_extension,
+                    formats.image_extension)
 

--- a/dwi_metadata/tests.py
+++ b/dwi_metadata/tests.py
@@ -1,27 +1,37 @@
 #!/usr/bin/python3
 
+from dataclasses import dataclass
 import json
 import logging
-import numpy as np
 import os
 from os import path as op
 import subprocess
+import sys
+import numpy as np
 from tqdm import tqdm
 
 from collections import namedtuple
 
+from . import ACQUISITIONS
 from . import GRADTABLE_FIDUCIALS
 from . import PEDIRS
 from . import PLANES
 from . import SLICEORDERS
-from . import VARIANTS
+from . import GradType
+from . import KeyvalueType
+from . import PEType
 from . import utils
 
 logger = logging.getLogger(__name__)
 
+@dataclass
+class MetadataTests:
+    gradtable: bool
+    phase_encoding: bool
+    slice_encoding: bool
 
 
-def metadata(testname, inputdir, file_extensions):
+def metadata(testname, inputdir, formats, tests):
 
     Mismatch = namedtuple('Mismatch', ['variant',
                                        'metadata_code',
@@ -36,20 +46,30 @@ def metadata(testname, inputdir, file_extensions):
     phaseencodingdirection_errors = []
     gradtable_errors = []
     logger.debug(f'Verifying metadata for {testname}:')
-    for v in tqdm(VARIANTS, desc=f'Verifying metadata for {testname}', leave=False):
-        logger.debug(f'  Variant {v}:')
+    for acq in tqdm(ACQUISITIONS, desc=f'Verifying metadata for {testname}', leave=False):
+        logger.debug(f'  Variant {acq}:')
+        transform = utils.get_transform(op.join(inputdir, f'{acq}.{formats.image_extension}'))
+        transform_linear = np.array([row[0:3] for row in transform[0:3]])
+        slicetimingreversal_metadata = None
         bvecs = None
         dw_scheme = None
-        if 'json' in file_extensions:
-            with open(op.join(inputdir, f'{v}.json'), 'r') as f:
-                metadata = json.loads(f.read())
-            slicetimingreversal_metadata = metadata['SliceTiming'][0] > metadata['SliceTiming'][-1]
-            transform = utils.get_transform(op.join(inputdir, f'{v}.{file_extensions[0]}'))
-            assert 'dw_scheme' not in metadata
-        else:
-            assert file_extensions == ['mih']
+        metadata = None
+        if (tests.phase_encoding and formats.pe_type == PEType.json) \
+                or (tests.slice_encoding and formats.keyvalue_type == KeyvalueType.json):
+            try:
+                with open(op.join(inputdir, f'{acq}.json'), 'r') as f:
+                    metadata = json.loads(f.read())
+            except FileNotFoundError as e:
+                raise FileNotFoundError(f'Missing JSON file for {testname} ({tests})') from e
+            try:
+                slicetimingreversal_metadata = metadata['SliceTiming'][0] > metadata['SliceTiming'][-1]
+            except KeyError:
+                pass
+        elif (tests.phase_encoding and formats.pe_type == PEType.header) \
+                or (tests.slice_encoding and formats.keyvalue_type == KeyvalueType.header):
+            assert formats.image_extension == 'mih'
             metadata = {}
-            with open(op.join(inputdir, f'{v}.{file_extensions[0]}'), 'r') as f:
+            with open(op.join(inputdir, f'{acq}.mih'), 'r') as f:
                 for line in f.readlines():
                     line = line.strip()
                     if line == 'mrtrix image':
@@ -64,95 +84,138 @@ def metadata(testname, inputdir, file_extensions):
                             metadata[line_split[0]] = [metadata[line_split[0]], line_split[1]]
                     else:
                         metadata[line_split[0]] = line_split[1]
-            slicetiming_metadata = [float(f) for f in metadata['SliceTiming'].split(',')]
-            slicetimingreversal_metadata = slicetiming_metadata[0] > slicetiming_metadata[-1]
+            if 'SliceTiming' in metadata:
+                slicetiming_metadata = [float(f) for f in metadata['SliceTiming'].split(',')]
+                slicetimingreversal_metadata = slicetiming_metadata[0] > slicetiming_metadata[-1]
             transform = [ [int(round(float(f))) for f in line.split(',')] for line in metadata['transform'] ]
-            dw_scheme = [ list(map(float, line.split(','))) for line in metadata['dw_scheme'] ]
-        if 'grad' in file_extensions:
-            assert 'dw_scheme' not in metadata
-            dw_scheme = []
-            with open(op.join(inputdir, f'{v}.grad'), 'r') as f:
-                for line in f.readlines():
-                    if line.startswith('#'):
-                        continue
-                    dw_scheme.append(line)
-            dw_scheme = [ list(map(float, line.split())) for line in dw_scheme ]
-            assert all(len(line) == 4 for line in dw_scheme)
-        elif 'bvec' in file_extensions:
-            with open(op.join(inputdir, f'{v}.bvec'), 'r') as f:
-                bvecs = [ list(map(float, line.split(' '))) for line in f.readlines()]
-            assert len(bvecs) == 3
-            assert len(bvecs[1]) == len(bvecs[0]) and len(bvecs[2]) == len(bvecs[0])
+        if tests.gradtable:
+            if formats.grad_type == GradType.header:
+                dw_scheme = [ list(map(float, line.split(','))) for line in metadata['dw_scheme'] ]
+            elif formats.grad_type == GradType.b:
+                assert 'dw_scheme' not in metadata
+                dw_scheme = []
+                with open(op.join(inputdir, f'{acq}.grad'), 'r') as f:
+                    for line in f.readlines():
+                        if line.startswith('#'):
+                            continue
+                        dw_scheme.append(line)
+                dw_scheme = [ list(map(float, line.split())) for line in dw_scheme ]
+                assert all(len(line) == 4 for line in dw_scheme)
+            elif formats.grad_type == GradType.fsl:
+                with open(op.join(inputdir, f'{acq}.bvec'), 'r') as f:
+                    bvecs = [ list(map(float, line.split(' '))) for line in f.readlines()]
+                assert len(bvecs) == 3
+                assert len(bvecs[1]) == len(bvecs[0]) and len(bvecs[2]) == len(bvecs[0])
+        phaseencodingdirection_metadata = None
+        if formats.pe_type in (PEType.header, PEType.json):
+            phaseencodingdirection_metadata = utils.code2direction(metadata['PhaseEncodingDirection'], transform)
+        elif formats.pe_type == PEType.table:
+            petable = np.loadtxt(op.join(inputdir, f'{acq}.petable'))
+            assert all(np.array_equal(petable[rowidx,:], petable[0,:]) for rowidx in range(1, petable.shape[0]))
+            pedir_image = petable[0][0:3]
+            assert sum(map(bool, pedir_image)) == 1
+            assert np.linalg.norm(pedir_image) == 1.0
+            phaseencodingdirection_metadata = np.dot(transform_linear, pedir_image).tolist()
+        elif formats.pe_type == PEType.topup:
+            topupdata = np.loadtxt(op.join(inputdir, f'{acq}.topup'))
+            assert all(np.array_equal(topupdata[rowidx,:], topupdata[0,:]) for rowidx in range(1, topupdata.shape[0]))
+            pedir_image = topupdata[0][0:3]
+            if np.linalg.det(transform_linear) > 0.0:
+                pedir_image[0] *= -1.0
+            assert sum(map(bool, pedir_image)) == 1
+            assert np.linalg.norm(pedir_image) == 1.0
+            phaseencodingdirection_metadata = np.dot(transform_linear, pedir_image).tolist()
+        elif formats.pe_type == PEType.eddy:
+            eddycfg = np.loadtxt(op.join(inputdir, f'{acq}.eddycfg'))
+            assert len(eddycfg.shape) == 1
+            pedir_image = eddycfg[0:3]
+            if np.linalg.det(transform_linear) > 0.0:
+                pedir_image[0] *= -1.0
+            with open(op.join(inputdir, f'{acq}.eddyidx'), 'r') as f:
+                eddyidx = list(map(int, f.read().strip().split(' ')))
+            assert all(value == 1 for value in eddyidx)
+            phaseencodingdirection_metadata = np.dot(transform_linear, pedir_image).tolist()
 
-        assert bvecs or dw_scheme
+        # Can no longer assert this; not all tests will involve gradient tables
+        #assert bvecs or dw_scheme
         assert not (bvecs is not None and dw_scheme is not None)
 
         # Slice encoding direction not explicitly labelled in dcm2niix JSON;
         #   therefore if absent we'll have to assume "k"
-        if 'SliceEncodingDirection' not in metadata:
-            if 'dcm2niix' in inputdir:
-                metadata['SliceEncodingDirection'] = 'k'
-            else:
-                raise KeyError('"SliceEncodingDirection" missing from ' + op.join(inputdir, f'{v}'))
-        sliceencodingdirection_metadata = utils.code2direction(metadata['SliceEncodingDirection'], transform)
-        if slicetimingreversal_metadata:
-            sliceencodingdirection_metadata = [-i if i else 0 for i in sliceencodingdirection_metadata]
-        phaseencodingdirection_metadata = utils.code2direction(metadata['PhaseEncodingDirection'], transform)
+        # TODO With latest changes this is likely to be unavailable in some circumstances
+        if tests.slice_encoding:
+            assert metadata is not None, f"No metadata for {testname}"
+            assert slicetimingreversal_metadata is not None
 
-        sliceencodingdirection_seriesdescription = [i * SLICEORDERS[v.sliceorder] for i in PLANES[v.plane]]
-        phaseencodingdirection_seriesdescription = PEDIRS[v.pedir]
+            if 'SliceEncodingDirection' not in metadata:
+                if 'dcm2niix' in inputdir:
+                    metadata['SliceEncodingDirection'] = 'k'
+                else:
+                    raise KeyError('Expected "SliceEncodingDirection" missing from ' + op.join(inputdir, f'{acq}'))
+            sliceencodingdirection_metadata = utils.code2direction(metadata['SliceEncodingDirection'], transform)
+            if slicetimingreversal_metadata:
+                sliceencodingdirection_metadata = [-i if i else 0 for i in sliceencodingdirection_metadata]
 
-        if sliceencodingdirection_metadata != sliceencodingdirection_seriesdescription:
-            sliceencodingdirection_errors.append(Mismatch(f'{v}',
-                                                          metadata['SliceEncodingDirection'],
-                                                          slicetimingreversal_metadata,
-                                                          sliceencodingdirection_metadata,
-                                                          v.plane,
-                                                          SLICEORDERS[v.sliceorder],
-                                                          sliceencodingdirection_seriesdescription,
-                                                          transform))
-        if phaseencodingdirection_metadata != phaseencodingdirection_seriesdescription:
-            phaseencodingdirection_errors.append(Mismatch(f'{v}',
-                                                          metadata['PhaseEncodingDirection'],
-                                                          False,
-                                                          phaseencodingdirection_metadata,
-                                                          v.pedir,
-                                                          False,
-                                                          phaseencodingdirection_seriesdescription,
-                                                          transform))
+            sliceencodingdirection_seriesdescription = [i * SLICEORDERS[acq.sliceorder] for i in PLANES[acq.plane]]
 
-        if dw_scheme:
-            fiducials = np.array([[int(round(f)) for f in dw_scheme[row][0:3]] for row in range(1, 4)])
-            if not np.array_equal(fiducials, GRADTABLE_FIDUCIALS):
-                gradtable_errors.append([f'{v}', fiducials])
-        else:
-            # Validate bvecs
-            # Ideally do this based on description of the format,
-            #   rather than relying on MRtrix3 commands,
-            #   given that we may need to use this test to validate the latter
-            #
-            # Skip the first b=0 volume
-            bvecs_fiducials = np.array([row[1:4] for row in bvecs])
-            logger.debug(f'    Stored bvec fiducials: {bvecs_fiducials.round()}')
-            transform_linear = np.array([row[0:3] for row in transform[0:3]])
-            logger.debug('    Transform: ' + str(transform_linear.round()))
-            #sys.stderr.write('transform_linear: ' + str(transform_linear) + '\n')
-            # We transpose the vectors so that they can be premultiplied by the transform matrix
-            fiducials_image = np.transpose(bvecs_fiducials)
-            # Invert the first element of each 3-vector if necessary
-            if np.linalg.det(transform_linear) > 0.0:
-                fiducials_image[:,0] *= -1.0
-            logger.debug(f'    Transposed & flipped imagespace fiducials: {fiducials_image.round()}')
-            # Transform fiducials from being defined with respect to image axes
-            #   to being defined with respect to scanner axes
-            #fiducials_real = np.matmul(transform_linear, fiducials_image).round()
-            fiducials_real = np.zeros((3,3))
-            for gradindex in range(0,3):
-                fiducials_real[gradindex] = np.dot(transform_linear, fiducials_image[gradindex,:])
-            #sys.stderr.write('Transform from bvecs ' + str(bvecs_fiducials) + ' to imagespace' + str(fiducials_image) + ' to scannerspace ' + str(fiducials_real) + '\n')
-            logger.debug('    Realspace fiducials: ' + str(fiducials_real.round()))
-            if not np.array_equal(fiducials_real.round(), GRADTABLE_FIDUCIALS):
-                gradtable_errors.append([f'{v}', fiducials_real])
+            if sliceencodingdirection_metadata != sliceencodingdirection_seriesdescription:
+                sliceencodingdirection_errors.append(Mismatch(f'{acq}',
+                                                              metadata['SliceEncodingDirection'],
+                                                              slicetimingreversal_metadata,
+                                                              sliceencodingdirection_metadata,
+                                                              acq.plane,
+                                                              SLICEORDERS[acq.sliceorder],
+                                                              sliceencodingdirection_seriesdescription,
+                                                              transform))
+
+        if tests.phase_encoding:
+            phaseencodingdirection_seriesdescription = PEDIRS[acq.pedir]
+            if phaseencodingdirection_metadata != phaseencodingdirection_seriesdescription:
+                phaseencodingdirection_errors.append(Mismatch(f'{acq}',
+                                                            metadata['PhaseEncodingDirection'] \
+                                                            if formats.pe_type in (PEType.json, PEType.header) \
+                                                            else 'N/A',
+                                                            False,
+                                                            phaseencodingdirection_metadata,
+                                                            acq.pedir,
+                                                            False,
+                                                            phaseencodingdirection_seriesdescription,
+                                                            transform))
+
+        if tests.gradtable:
+            if formats.grad_type in (GradType.b, GradType.header):
+                assert dw_scheme
+                fiducials = np.array([[int(round(f)) for f in dw_scheme[row][0:3]] for row in range(1, 4)])
+                if not np.array_equal(fiducials, GRADTABLE_FIDUCIALS):
+                    gradtable_errors.append([f'{acq}', fiducials])
+            elif formats.grad_type == GradType.fsl:
+                # Validate bvecs
+                # Ideally do this based on description of the format,
+                #   rather than relying on MRtrix3 commands,
+                #   given that we may need to use this test to validate the latter
+                #
+                # Skip the first b=0 volume
+                bvecs_fiducials = np.array([row[1:4] for row in bvecs])
+                logger.debug(f'    Stored bvec fiducials: {bvecs_fiducials.round()}')
+                transform_linear = np.array([row[0:3] for row in transform[0:3]])
+                logger.debug('    Transform: ' + str(transform_linear.round()))
+                #sys.stderr.write('transform_linear: ' + str(transform_linear) + '\n')
+                # We transpose the vectors so that they can be premultiplied by the transform matrix
+                fiducials_image = np.transpose(bvecs_fiducials)
+                # Invert the first element of each 3-vector if necessary
+                if np.linalg.det(transform_linear) > 0.0:
+                    fiducials_image[:,0] *= -1.0
+                logger.debug(f'    Transposed & flipped imagespace fiducials: {fiducials_image.round()}')
+                # Transform fiducials from being defined with respect to image axes
+                #   to being defined with respect to scanner axes
+                #fiducials_real = np.matmul(transform_linear, fiducials_image).round()
+                fiducials_real = np.zeros((3,3))
+                for gradindex in range(0,3):
+                    fiducials_real[gradindex] = np.dot(transform_linear, fiducials_image[gradindex,:])
+                #sys.stderr.write('Transform from bvecs ' + str(bvecs_fiducials) + ' to imagespace' + str(fiducials_image) + ' to scannerspace ' + str(fiducials_real) + '\n')
+                logger.debug('    Realspace fiducials: ' + str(fiducials_real.round()))
+                if not np.array_equal(fiducials_real.round(), GRADTABLE_FIDUCIALS):
+                    gradtable_errors.append([f'{acq}', fiducials_real])
 
     logger.info(f'Results for {testname}:')
     if sliceencodingdirection_errors:
@@ -182,7 +245,7 @@ def metadata(testname, inputdir, file_extensions):
 def peaks(testname, inputdir, maskdir, image_extension, mask_extension):
     errors = []
     logger.info(f'Verifying peak orientations for {testname}')
-    for v in tqdm(VARIANTS, desc=f'Verifying peak orientations for {testname}', leave=False):
+    for v in tqdm(ACQUISITIONS, desc=f'Verifying peak orientations for {testname}', leave=False):
         logger.debug(f'  Variant {v}')
         maskpath = op.join(maskdir, 'temp.mif')
         proc = subprocess.run(['maskfilter', op.join(maskdir, f'{v}.{mask_extension}'), 'erode', maskpath,

--- a/dwi_metadata/utils.py
+++ b/dwi_metadata/utils.py
@@ -33,7 +33,7 @@ def get_transform(image_path):
                                 capture_output=True,
                                 text=True).stdout
     if not transform:
-        if op.exists(image_path):
+        if os.path.exists(image_path):
             raise ValueError(f'Unable to read transform from "{image_path}"')
         raise FileNotFoundError(f'No transform read for "{image_path}" as file does not exist')
     try:


### PR DESCRIPTION
- Test converting from internal phase encoding table representation to different formats and then reimporting them.
- Test running FSL topup and applytopup for as many different image encodings as possible. A test for FSL eddy will come subsequently; it is currently disabled due to unreasonable computation time.